### PR TITLE
Parse sitemaps values with full urls correctly

### DIFF
--- a/spec/Roboxt/ParserSpec.php
+++ b/spec/Roboxt/ParserSpec.php
@@ -35,4 +35,22 @@ TEXT;
         $googlebot->shouldBeAnInstanceOf('Roboxt\UserAgent');
         $googlebot->allDirectives()->shouldHaveCount(2);
     }
+
+    function it_should_parse_the_robots_txt_file_with_sitemap_containing_urls()
+    {
+        $content = <<<TEXT
+User-Agent: *
+Sitemap: https://foo.bar.com/sitemap.xml
+TEXT;
+        $filepath = sys_get_temp_dir().'/robots.txt';
+
+        file_put_contents($filepath, $content);
+
+        $file = $this->parse($filepath);
+        $directives = $file->getUserAgent('*')->allDirectives();
+        $directives->get(0)->getName()->shouldReturn('Sitemap');
+        $directives->get(0)->getValue()->shouldReturn('https://foo.bar.com/sitemap.xml');
+
+        unlink($filepath);
+    }
 }

--- a/src/Roboxt/Parser.php
+++ b/src/Roboxt/Parser.php
@@ -43,7 +43,9 @@ class Parser
                 continue;
             }
 
-            list($name, $value) = explode(':', $content);
+            $separatorPosition = strpos($content, ':');
+            $name = substr($content, 0, $separatorPosition);
+            $value = trim(substr($content, $separatorPosition + 1));
             $directive = new Directive($name, trim($value));
 
             // If the directive's name is "User-Agent" then register a UserAgent in the file


### PR DESCRIPTION
The following directive was not parsed correctly

```
Sitemap: https://www.google.com/edu/sitemap.xml
```

| status | name | value |
| --- | --- | --- |
| ✘ | https |  |
| ✔ | Sitemap | https://www.google.com/edu/sitemap.xml |
