### PR TITLE
Add branch alias for 1.2.x@dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
     "minimum-stability": "dev",
     "autoload": {
         "psr-0": {"Roboxt": "src/"}
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.2-dev"
+        }
     }
 }


### PR DESCRIPTION
So people can require the latest version using `1.2.x@dev` (assuming 1.2.0 is going to be the next release)